### PR TITLE
[Refactor] Compare arcademode on name instead of id

### DIFF
--- a/src/services/modes.ts
+++ b/src/services/modes.ts
@@ -1,9 +1,4 @@
-enum ModeId {
-  MAYHEM = 71,
-}
-
 export type Mode = {
-  id: ModeId;
   name: string;
 };
 
@@ -38,4 +33,4 @@ export const getTodaysModes = async (): Promise<TodayModes> => {
 };
 
 export const isItMayhem = (modes: Modes) =>
-  !!Object.values(modes).find((mode) => mode.id === ModeId.MAYHEM);
+  !!Object.values(modes).find((mode) => mode.name === "Total Mayhem");


### PR DESCRIPTION
Arcademode ids get changed around every so often when I re-extract them from the game. Therefor you shouldn't rely on id checks. My mistake on the API design. Thought I'd let you know and at the same time fix it for you, it's a small effort :)

Also I'm busy reworking OverwatchArcade.today to a separate back-end and front-end meaning the API will change and it'll be code breaking. If you're interested I can give you a heads-up whenever I plan on releasing that. 